### PR TITLE
Alloc Instrumentation in Shmem

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -1822,6 +1822,11 @@ ExecEndNode(PlanState *node)
 			break;
 	}
 
+	if (node->instrument) {
+		InstrFree(node->instrument);
+		node->instrument = NULL;
+	}
+
 	if (codegen)
 	{
 		/*

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -830,7 +830,13 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 
 	/* Set up instrumentation for this node if requested */
 	if (estate->es_instrument && result != NULL)
+	{
 		result->instrument = InstrAlloc(1);
+		if (result->instrument->in_shmem)
+		{
+			((InstrumentationSlot*)result->instrument)->nid = node->plan_node_id;
+		}
+	}
 
 	if (result != NULL)
 	{

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -98,6 +98,8 @@ InstrAlloc(int n)
 			GetInstrumentNext(slot) = NULL;
 			instr = &(slot->data);
 			instr->in_shmem = true;
+			slot->segid = Gp_segment;
+			slot->pid = MyProcPid;
 		}
 	}
 

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -67,6 +67,7 @@
 #include "utils/tqual.h"
 #include "postmaster/backoff.h"
 #include "cdb/memquota.h"
+#include "executor/instrument.h"
 #include "executor/spi.h"
 #include "utils/workfile_mgr.h"
 #include "utils/session_state.h"
@@ -233,6 +234,9 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 
 		/* Consider the size of the SessionState array */
 		size = add_size(size, SessionState_ShmemSize());
+
+		/* size of Instrumentation slots */
+		size = add_size(size, InstrShmemSize());
 
 		/*
 		 * Create the shmem segment
@@ -405,6 +409,12 @@ CreateSharedMemoryAndSemaphores(bool makePrivate, int port)
 	SyncScanShmemInit();
 	workfile_mgr_cache_init();
 	BackendCancelShmemInit();
+
+	/*
+	 * Set up Instrumentation free list
+	 */
+	if (!IsUnderPostmaster)
+		InstrShmemInit();
 
 #ifdef EXEC_BACKEND
 

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -1028,6 +1028,10 @@ PortalRun(Portal portal, int64 count, bool isTopLevel,
 		if (portal->queryDesc)
 			mppExecutorCleanup(portal->queryDesc);
 
+		/* Cleanup Instrumentation slots */
+		if (portal->queryDesc && portal->queryDesc->planstate)
+			InstrumentCleanup(portal->queryDesc->planstate);
+
 		/* Restore global vars and propagate error */
 		if (saveMemoryContext == saveTopTransactionContext)
 			MemoryContextSwitchTo(TopTransactionContext);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -498,6 +498,7 @@ extern GpExecIdentity getGpExecIdentity(QueryDesc *queryDesc,
 extern void mppExecutorFinishup(QueryDesc *queryDesc);
 extern void mppExecutorCleanup(QueryDesc *queryDesc);
 
+extern void InstrumentCleanup(PlanState *ps);
 
 /* prototypes defined in nodeAgg.c for rollup-aware Agg/Group nodes. */
 extern int64 tuple_grouping(TupleTableSlot *outerslot, int numGroupCols,


### PR DESCRIPTION
- Additional 3 MB will be allocated for Instrumentation in shmem when Postmaster starts
- This additional space are used for initializing 20000 slots of Instrumentation and a header
- The 20000 slots are organized as a free list
    - header pointing to the first free slot
    - each free slot points to next free slot
    - the last free slot's next pointer is NULL
- When GUC gp_enable_query_metrics is on, InstrAlloc called from ExecInitNode will pick an empty slot from the free list to store Instrumentation.
    - The free slot pointed by the header is picked
    - The picked slot's next pointer is assigned to the header
    - A spin lock to the header to prevent concurrently write to the header.
    - When the GUC is off, Instrumentation will still be allocated in local memory.
- On ExecEndNode or query finished with exception (PortalRun), the occupied slot is cleaned up and returned to the free list
    - The returning slot is wiped with all zero
    - The returning slot's next pointer is set to the current value of header
    - The header is pointed to the returning slot
    - A spin lock is also used to protect header